### PR TITLE
Missing count variable

### DIFF
--- a/Samples/Tests/IconDrawableTests.swift
+++ b/Samples/Tests/IconDrawableTests.swift
@@ -132,8 +132,8 @@ class IconDrawableTests: XCTestCase {
             let range = NSRange(location: 0, length: string.length)
 
             XCTAssertNotNil(string)
-
-            string.enumerateAttribute(NSFontAttributeName, in: range, options: NSAttributedString.EnumerationOptions(rawValue: 0)) { (value, range, stop) -> Void in
+            
+            string.enumerateAttribute(NSAttributedString.Key.font, in: range, options: NSAttributedString.EnumerationOptions(rawValue: 0)) { (value, range, stop) -> Void in
                 if let font = value as? UIFont {
                     XCTAssertEqual(font.familyName, TestIcon.familyName)
                 }

--- a/Samples/Tests/StringIconSnapshotTests.swift
+++ b/Samples/Tests/StringIconSnapshotTests.swift
@@ -55,8 +55,8 @@ class StringIconSnapshotTests: BaseSnapshotTestCase {
             let attributedText = NSMutableAttributedString()
             let iconString = icon.attributedString(ofSize: 25, color: nil, edgeInsets: edgeInset)
 
-            let titleAttributes = [NSFontAttributeName: UIFont.systemFont(ofSize: 25),
-                                   NSForegroundColorAttributeName: UIColor.black] as [String : AnyObject]
+            let titleAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 25),
+                                   NSAttributedString.Key.foregroundColor: UIColor.black]
 
             let titleAttrString = NSAttributedString(string: icon.name, attributes: titleAttributes)
 

--- a/Samples/Tests/UIExtensionSnapshotTests.swift
+++ b/Samples/Tests/UIExtensionSnapshotTests.swift
@@ -44,7 +44,7 @@ class UIExtensionSnapshotTests: BaseSnapshotTestCase {
     func testUIButton() {
 
         let button = UIButton(type: .system)
-        button.setIconImage(withIcon: .downloadIcon, size: defaultSize, color: nil, forState: UIControlState())
+        button.setIconImage(withIcon: .downloadIcon, size: defaultSize, color: nil, forState: UIControl.State())
         button.sizeToFit()
 
         self.verifyView(button, withIdentifier: "")

--- a/Source/iconic-default.stencil
+++ b/Source/iconic-default.stencil
@@ -11,6 +11,11 @@ import UIKit
         return {{enumName}}.familyName as NSString
     }
 
+    /** The icon font's total count of available icons. */
+    class var {{enumName|lowerFirstWord}}Count: NSInteger {
+        return {{enumName}}.count
+    }
+
     /**
      Returns the icon font object for the specified size.
 
@@ -171,6 +176,11 @@ extension {{enumName}} : IconDrawable {
     /** The icon font's family name. */
     public static var familyName: String {
         return "{{familyName}}"
+    }
+
+    /** The icon font's total count of available icons. */
+    public static var count: Int { 
+        return {{ icons.count }}
     }
 
     /**


### PR DESCRIPTION
Description:
When I tried to integrate Iconic with my project, I got an error: 
```FontAwesomeIcon' does not conform to protocol 'IconDrawable```. 

```IconDrawable``` declares ```count``` variable which was not part of the stencil file and SwiftGen didn't generate the necessary code.

Also when running unit and ui tests, I noticed some obsolete syntax, so updated it to Swift 4.2.


