### PR TITLE
Swift 5 compatibility (and enum exhaustive check timeout) #87

### DIFF
--- a/Iconic.podspec
+++ b/Iconic.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target    = '9.0'
   s.watchos.deployment_target = '2.0'
 
-  s.swift_version             = '4.2'
+  s.swift_version             = '5.0'
 
   s.prepare_command           = "sh Source/Iconizer.sh '#{ENV['FONT_PATH']}' '#{ENV['CUSTOM_FONT_NAME']}'"
 end

--- a/Source/iconic-default.stencil
+++ b/Source/iconic-default.stencil
@@ -221,6 +221,7 @@ extension {{enumName}} : IconDrawable {
         {% for icon in icons %}
         case .{{icon.name|swiftIdentifier|snakeToCamelCase|lowerFirstWord}}Icon: return "{{icon.name|swiftIdentifier|lowercase}}"
         {% endfor %}
+        default: fatalError("Iconic: .name not exhaustive")
         }
     }
 
@@ -230,6 +231,7 @@ extension {{enumName}} : IconDrawable {
             {% for icon in icons %}
         case .{{icon.name|swiftIdentifier|snakeToCamelCase|lowerFirstWord}}Icon: return "{{icon.unicode|unicodeCase}}"
             {% endfor %}
+            default: fatalError("Iconic: .unicode not exhaustive")
         }
     }
 }


### PR DESCRIPTION
Resolves #87
Added a default case handler, and because the return type is not optional and we cannot throw inside a computed var it just does fatalError() with a message of where.
Assuming we never had this before and it IS exhaustive, the compiler just doesn't know it - it won't be an issue.

Bumped swift to 5.0 without any other changes to remove compiler warning.
Perhaps @robbiet480 is suitable reviewer?

Edit: This has been tested with a clean branch install and generates without issue or compiler warning in Xcode 11.3 and cocoa pods 1.8.4