### PR TITLE
Optimizing compiler check on some variables

### DIFF
--- a/Source/iconic-default.stencil
+++ b/Source/iconic-default.stencil
@@ -221,6 +221,7 @@ extension {{enumName}} : IconDrawable {
         {% for icon in icons %}
         case .{{icon.name|swiftIdentifier|snakeToCamelCase|lowerFirstWord}}Icon: return "{{icon.name|swiftIdentifier|lowercase}}"
         {% endfor %}
+        default: return ""
         }
     }
 
@@ -230,6 +231,7 @@ extension {{enumName}} : IconDrawable {
             {% for icon in icons %}
         case .{{icon.name|swiftIdentifier|snakeToCamelCase|lowerFirstWord}}Icon: return "{{icon.unicode|unicodeCase}}"
             {% endfor %}
+        default: return ""
         }
     }
 }


### PR DESCRIPTION
The compiler fails to check how exhaustive some switches are with the warning "The compiler is unable to check that this switch is exhaustive in reasonable time". 

The easiest solution is to add a `default` to these switch statements, to trick the compiler.

Fix https://github.com/home-assistant/Iconic/issues/87